### PR TITLE
diff output change

### DIFF
--- a/preserve.sh
+++ b/preserve.sh
@@ -76,7 +76,7 @@ copy_and_diff() {
 
   LC_ALL=C # Sort by ASCII: Differences in locale meant the traversal order was different.
 
-  diff -qrs $L_SOURCE $L_DEST > $L_METADATA/diff/`basename $L_DEST`.diff
+  diff -qrs $L_SOURCE $L_DEST >> $L_METADATA/diff/`basename $L_DEST`.diff
 }
 
 message 'copy_and_diff'


### PR DESCRIPTION
@mccalluc Using `>` when writing the diff.txt file was overwriting when entering multiple DEST locations.
I tested by adding `>>` and it lists all the diffs for the given DEST locations.
If you have a better way to do this, feel free to change.
