### PR TITLE
disguise inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
         <style>
             body {
                 font-family: sans-serif;
+                font-size: 1em;
             }
 
             /* Conditional swapping of input */
@@ -16,6 +17,9 @@
             }
             #output .jstree-clicked input {
                 display: inline;
+                /* Disguise the fact that it's an input, since we do not allow edits. */
+                font-size: 1em; 
+                border: none;
             }
             #output .jstree-clicked .basename {
                 display: none;


### PR DESCRIPTION
@Muraszko ?
<img width="373" alt="screen shot 2016-06-13 at 10 59 46 am" src="https://cloud.githubusercontent.com/assets/730388/16012182/567ac478-3156-11e6-917b-ae21982ae360.png">

By hiding the border and increasing the font size, we avoid the suggestion that the field can be edited.
