### PR TITLE
44 - Adds Flag to Delete Hidden Files From Source

### DIFF
--- a/preserve.rb
+++ b/preserve.rb
@@ -72,7 +72,7 @@ clean_names(source)
 ####################
 
 def remove_hidden_files(source)
-  message('hidden files')
+  message('remove_hidden_files')
   hidden_files = []
   Find.find(source).each do |file|
     next if File.directory?(file)

--- a/preserve.rb
+++ b/preserve.rb
@@ -76,7 +76,7 @@ def remove_hidden_files(source)
   hidden_files = []
   Find.find(source).each do |file|
     next if File.directory?(file)
-    hidden_files << file if file.split('/')[-1] =~ /^\./
+    hidden_files << file if File.basename(file) =~ /^\./
   end
 
   hidden_files.each { |path| File.delete(path) if File.exists?(path) }

--- a/preserve.rb
+++ b/preserve.rb
@@ -103,8 +103,6 @@ File.write(
 def fork_copy_diff(source, metadata, dest, i)
   fork do
     FileUtils.cp_r(source, dest)
-    # rsync = `rsync -a --exclude='.*' #{source} #{dest}`
-
     `#{ENV['HOOK']}` if ENV['HOOK']
     FileUtils.mkdir_p("#{metadata}/diff")
     diff = `diff -qrs --exclude='.*' '#{dest}' '#{source}'`.split("\n").sort.join("\n") + "\n"# Stable order

--- a/spec/fixtures/example-good/output/metadata 0/diff/dest-0.txt
+++ b/spec/fixtures/example-good/output/metadata 0/diff/dest-0.txt
@@ -1,2 +1,2 @@
-Files tmp/input/bad_dir_name/bad_file_name.mov and tmp/output/dest 1/bad_dir_name/bad_file_name.mov are identical
-Files tmp/input/ok name/ok name.txt and tmp/output/dest 1/ok name/ok name.txt are identical
+Files tmp/output/dest 1/bad_dir_name/bad_file_name.mov and tmp/input/bad_dir_name/bad_file_name.mov are identical
+Files tmp/output/dest 1/ok name/ok name.txt and tmp/input/ok name/ok name.txt are identical

--- a/spec/fixtures/example-good/output/metadata 0/diff/dest-1.txt
+++ b/spec/fixtures/example-good/output/metadata 0/diff/dest-1.txt
@@ -1,2 +1,2 @@
-Files tmp/input/bad_dir_name/bad_file_name.mov and tmp/output/dest 2/bad_dir_name/bad_file_name.mov are identical
-Files tmp/input/ok name/ok name.txt and tmp/output/dest 2/ok name/ok name.txt are identical
+Files tmp/output/dest 2/bad_dir_name/bad_file_name.mov and tmp/input/bad_dir_name/bad_file_name.mov are identical
+Files tmp/output/dest 2/ok name/ok name.txt and tmp/input/ok name/ok name.txt are identical


### PR DESCRIPTION
@afred - This adds a "no-hidden" flag to the script that cleans out all the hidden files prior to processing if it is set. This also fixes the bash test script from when it was broken by PR #42. The PR swapped the dest and source in the diff during fork_copy_diff. This just required swapping the expectations in the fixtures.